### PR TITLE
Add screenshot tool to MCP server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,10 @@ import {
 } from './tools/log.js';
 
 import { version } from './version.js';
+
+// Import screenshot tool
+import { registerTakeScreenshotTool } from './tools/screenshot.js';
+
 /**
  * Main function to start the server
  */
@@ -142,6 +146,9 @@ async function main(): Promise<void> {
     // Register log capture tools
     registerStartSimulatorLogCaptureTool(server);
     registerStopAndGetSimulatorLogTool(server);
+
+    // Register screenshot tool
+    registerTakeScreenshotTool(server);
 
     // Start the server
     await startServer(server);

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import { execSync } from 'child_process';
+import { log } from '../utils/logger.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { validateRequiredParam } from '../utils/validation.js';
+import { ToolResponse } from '../types/common.js';
+
+/**
+ * Takes a screenshot of the currently booted iOS simulator.
+ * IMPORTANT: You MUST provide the outputPath parameter.
+ * Example: take_screenshot({ outputPath: '/path/to/screenshot.png' })
+ */
+export function registerTakeScreenshotTool(server: McpServer): void {
+  server.tool(
+    'take_screenshot',
+    "Takes a screenshot of the currently booted iOS simulator. IMPORTANT: You MUST provide the outputPath parameter. Example: take_screenshot({ outputPath: '/path/to/screenshot.png' })",
+    {
+      outputPath: z
+        .string()
+        .describe('Path where the screenshot will be saved (full path to the .png file)'),
+    },
+    async (params): Promise<ToolResponse> => {
+      // Validate required parameters
+      const outputPathValidation = validateRequiredParam('outputPath', params.outputPath);
+      if (!outputPathValidation.isValid) {
+        return outputPathValidation.errorResponse!;
+      }
+
+      log('info', `Starting screenshot request for output path ${params.outputPath}`);
+
+      try {
+        // Construct the command
+        const command = `xcrun simctl io booted screenshot "${params.outputPath}"`;
+
+        // Execute the command
+        execSync(command);
+
+        // Return success response
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `✅ Screenshot taken successfully: ${params.outputPath}`,
+            },
+          ],
+        };
+      } catch (error) {
+        // Handle errors
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        log('error', `Error during screenshot operation: ${errorMessage}`);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `❌ Screenshot operation failed: ${errorMessage}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/src/tools/simulator.ts
+++ b/src/tools/simulator.ts
@@ -21,6 +21,7 @@ import { validateRequiredParam, validateFileExists } from '../utils/validation.j
 import { ToolResponse } from '../types/common.js';
 import { createTextContent } from './common.js';
 import { startLogCapture } from '../utils/log_capture.js';
+import { registerTakeScreenshotTool } from './screenshot.js';
 
 /**
  * Boots an iOS simulator. IMPORTANT: You MUST provide the simulatorUuid parameter. Example: boot_simulator({ simulatorUuid: 'YOUR_UUID_HERE' }) Note: In some environments, this tool may be prefixed as mcp0_boot_simulator.
@@ -495,3 +496,5 @@ export function registerOpenSimulatorTool(server: McpServer): void {
     },
   );
 }
+
+registerTakeScreenshotTool(server);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -25,3 +25,13 @@ export function log(level: string, message: string): void {
   const timestamp = new Date().toISOString();
   console.error(`[${timestamp}] [${level.toUpperCase()}] ${message}`);
 }
+
+/**
+ * Log a screenshot operation
+ * @param level The log level (info, warning, error, debug)
+ * @param message The message to log
+ */
+export function logScreenshot(level: string, message: string): void {
+  const timestamp = new Date().toISOString();
+  console.error(`[${timestamp}] [SCREENSHOT] [${level.toUpperCase()}] ${message}`);
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -202,5 +202,24 @@ export function validateEnumParam<T>(
   return { isValid: true };
 }
 
+/**
+ * Validates the output path for the screenshot tool
+ * @param outputPath Path where the screenshot will be saved
+ * @returns Validation result
+ */
+export function validateScreenshotOutputPath(outputPath: string): ValidationResult {
+  if (!outputPath.endsWith('.png')) {
+    return {
+      isValid: false,
+      errorResponse: createTextResponse(
+        `Invalid output path: '${outputPath}'. The screenshot output path must end with '.png'.`,
+        true,
+      ),
+    };
+  }
+
+  return { isValid: true };
+}
+
 // Export the ToolResponse type for use in other files
 export { ToolResponse, ValidationResult };


### PR DESCRIPTION
Add a new tool to take a screenshot of the simulator if it's running.

* **src/index.ts**
  - Import `registerTakeScreenshotTool` from `src/tools/screenshot.ts`.
  - Register `registerTakeScreenshotTool` with the server.

* **src/tools/screenshot.ts**
  - Create a new file to implement the screenshot functionality.
  - Define a function `registerTakeScreenshotTool` to register the tool.
  - Implement the logic to take a screenshot using `xcrun simctl io booted screenshot`.
  - Handle errors and return appropriate responses.

* **src/tools/simulator.ts**
  - Import `registerTakeScreenshotTool` from `src/tools/screenshot.ts`.
  - Register `registerTakeScreenshotTool` with the server.

* **src/utils/validation.ts**
  - Add validation for the screenshot tool parameters.

* **src/utils/logger.ts**
  - Add logging for the screenshot tool.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/joelklabo/XcodeBuildMCP/pull/1?shareId=a61d564e-aa38-4e18-a4bd-ad0689a1b61c).